### PR TITLE
Fixed the error case for non-renewing subscriptions where you try to subscribe with an existing subscription.

### DIFF
--- a/IAPManager.m
+++ b/IAPManager.m
@@ -179,6 +179,7 @@ NSURL *purchasesURL() {
             if(completion) completion(transaction);
         }
         else if(transaction.transactionState == SKPaymentTransactionStateFailed) {
+            [queue finishTransaction:transaction];
             if(err) err(transaction.error);
         }
     }


### PR DESCRIPTION
added [queue finishTransaction:transaction] in the error case so the failed transactions are removed.
