### PR TITLE
Persist purchased items when simulating purchases

### DIFF
--- a/IAPManager.m
+++ b/IAPManager.m
@@ -164,6 +164,7 @@ BOOL checkAppStoreAvailable() {
         PurchasedProductsChanged callback = t[0];
         callback();
     }
+    [self persistPurchasedItems];
     completionBlock(NULL);
 #else
     if(! [self canPurchase])
@@ -184,6 +185,7 @@ BOOL checkAppStoreAvailable() {
         PurchasedProductsChanged callback = t[0];
         callback();
     }
+    [self persistPurchasedItems];
     completionBlock(NULL);
 #else
     [self getProductsForIds:@[productId] completion:^(NSArray *products) {


### PR DESCRIPTION
When using IAPManager in Development, we use SIMULATE_PURCHASES macro. Very often the app is killed by pressing stop button in Xcode, so willResignActive is not called and items are not persisted so it's a bit tricky.